### PR TITLE
Correct compensated temperature calculation

### DIFF
--- a/bme280.py
+++ b/bme280.py
@@ -147,7 +147,7 @@ class BME280:
         self.read_raw_data(self._l3_resultarray)
         raw_temp, raw_press, raw_hum = self._l3_resultarray
         # temperature
-        var1 = ((raw_temp >> 3) - (self.dig_T1 << 1)) * (self.dig_T2 >> 11)
+        var1 = (((raw_temp >> 3) - (self.dig_T1 << 1)) * self.dig_T2) >> 11
         var2 = (((((raw_temp >> 4) - self.dig_T1) *
                   ((raw_temp >> 4) - self.dig_T1)) >> 12) * self.dig_T3) >> 14
         self.t_fine = var1 + var2


### PR DESCRIPTION
Depending on the value of the dig_T2 (of each individual sensor), the calculated **temperature is off by up to 2 °C**. Only a small change to the code ... but an important one ;-)

For a reference on correct calculation of compensated temperature, see the [Bosch Sensortec C-code line 1256-1257](https://github.com/boschsensortec/BME280_driver/blob/master/bme280.c)